### PR TITLE
[Web][Mobile] スマホ表示でオーグメント欄が潰れる問題を修正 (#2)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -695,6 +695,66 @@
             border-color: #f0c040;
         }
 
+        /* ===== モバイル向けレイアウト (縦積みカード) ===== */
+        /* PC のグリッド (7 列横並び) ではオーグメント欄が潰れて入力できないため、
+           狭い画面では各スロットを 4 行のカードに切り替える。 */
+        @media (max-width: 768px) {
+            .equip-slot-grid {
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+            }
+            .equip-slot-header {
+                display: none;
+            }
+            .equip-slot-row {
+                display: grid;
+                grid-template-columns: 56px 1fr auto;
+                grid-template-areas:
+                    "label   search   clear"
+                    "desc    desc     desc"
+                    "augpath augtext  augtext"
+                    "custom  custom   custom";
+                gap: 6px 8px;
+                padding: 8px;
+                background: #0f0f23;
+                border: 1px solid #2a2a40;
+                border-radius: 4px;
+            }
+            .equip-slot-label {
+                grid-area: label;
+                align-self: center;
+                text-align: left;
+            }
+            .equip-slot-input-wrapper {
+                grid-area: search;
+            }
+            .equip-slot-clear {
+                grid-area: clear;
+                align-self: center;
+            }
+            .equip-slot-description {
+                grid-area: desc;
+                max-height: none;
+            }
+            .equip-slot-aug-path {
+                grid-area: augpath;
+                width: 100%;
+            }
+            .equip-slot-aug-text {
+                grid-area: augtext;
+            }
+            .equip-slot-custom-desc {
+                grid-area: custom;
+                width: 100%;
+            }
+            /* 説明やAug説明が空のときは行高を 0 にして詰める */
+            .equip-slot-description:empty,
+            .equip-slot-aug-text:empty {
+                display: none;
+            }
+        }
+
         .status-section {
             margin-top: 20px;
             padding: 15px;


### PR DESCRIPTION
Closes #2

## Summary

PC では 7 列のグリッドで装備セットの 1 行を表示しており、合計幅が 約 1000px。
スマホ (CSS 幅 ~375-414px) ではオーグメント欄 (350px 想定) が潰れて入力できない
状態だった。

\`@media (max-width: 768px)\` で各 \`.equip-slot-row\` を 3 列 4 行のカード
レイアウトに切り替え、オーグメント関連の入力欄に十分な幅を確保する。

```
Row 1: [ラベル] [装備検索 ...] [×]
Row 2: [説明 (item description)]
Row 3: [Aug Path 選択] [Aug Text]
Row 4: [カスタム説明 input]
```

PC (>768px) のレイアウトは変更なし。

## Test plan
- [ ] スマホ実機 (Chrome / Safari) で装備セット画面を開き、オーグメント欄が
      入力可能になっているか確認
- [ ] スマホ実機で装備検索 / × ボタン / カスタム説明欄が触りやすいか確認
- [x] PC 表示が変わっていない (7 列グリッド維持) ことを確認