### PR TITLE
[Web][Mobile] スマホでオーグメントドロップダウンを全幅化

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -713,7 +713,8 @@
                 grid-template-areas:
                     "label   search   clear"
                     "desc    desc     desc"
-                    "augpath augtext  augtext"
+                    "augpath augpath  augpath"
+                    "augtext augtext  augtext"
                     "custom  custom   custom";
                 gap: 6px 8px;
                 padding: 8px;


### PR DESCRIPTION
PR #19 に続くスマホレイアウト調整。

## Summary

PR #19 の 3 列 4 行カード構成では aug-path が左 1 列 (56px) に潰れて
オーグメントパス名が読めなかった。aug-path と aug-text を別々の行に
分けて、各行を全幅 (3 列スパン) で使えるよう変更する。

```
Row 1: [ラベル] [装備検索...] [×]
Row 2: [説明 (item description)]
Row 3: [Aug Path 選択 ...... 全幅]
Row 4: [Aug Text ........... 全幅]
Row 5: [カスタム説明 input]
```

aug-text は \`:empty\` 時に \`display:none\` で行ごと崩壊するため、
オーグメント未選択時はカードの高さに影響しない。

Refs #2