### PR TITLE
[Fix] equip-stats のステ抽出ロジックを修正 (Unity Ranking 重畳 / Pet 系 strip 拡張)

### DIFF
--- a/web/js/equip-stats.js
+++ b/web/js/equip-stats.js
@@ -22,9 +22,12 @@ function extractAllStats(descriptionEn) {
         ' $1+$2'
     );
 
-    // Strip "Pet: ..." segments (apply only to summoned pets, not the wearer).
-    // Continue until the next ":"-prefixed section or end of string.
-    text = text.replace(/Pet:[^:]*/g, '');
+    // Strip pet-prefixed segments (apply only to summoned pets/avatar/wyvern/automaton,
+    // not the wearer). 次の ":" プレフィックスまで (改行を跨ぎうる) を取り除く。
+    // Pet 行は折り返しで複数行に分割されることがあり、すべて Pet 用 stats として扱う。
+    // 例: アスプロピアスの「Pet: Accuracy+15\nRanged Accuracy+15\nMagic Accuracy+15」は
+    //     3 行ともペット用なのでまとめて除外する (キャラに追加される魔命/飛命は augment 経由)。
+    text = text.replace(/(?:Pet|Avatar|Wyvern|Automaton):[^:]*/g, '');
 
     // 省略表記を正式名称に展開（AF3+3 などで使われる "Rng. Atk." 形式に対応）。
     // 順序が重要: 複合形を単純形より先に展開する。
@@ -50,13 +53,16 @@ function extractAllStats(descriptionEn) {
 
     const result = {};
 
-    // Helper: match a signed stat pattern like "STR+15" or "Attack +22"
+    // Helper: match a signed stat pattern like "STR+15" or "Attack +22".
+    // 全ての出現を合算する (Unity Ranking 効果が同名ステで重複するケース等に対応)。
     function matchSigned(pattern) {
-        const re = new RegExp(pattern, 'i');
-        const m = text.match(re);
-        if (!m) return 0;
-        const sign = m[1] === '-' ? -1 : 1;
-        return sign * parseInt(m[2], 10);
+        const re = new RegExp(pattern, 'gi');
+        let total = 0;
+        for (const m of text.matchAll(re)) {
+            const sign = m[1] === '-' ? -1 : 1;
+            total += sign * parseInt(m[2], 10);
+        }
+        return total;
     }
 
     // Helper: match a colon-format pattern like "DEF:77" or "DMG:+165"
@@ -67,14 +73,16 @@ function extractAllStats(descriptionEn) {
         return parseInt(m[1], 10);
     }
 
-    // Helper: match a value where the sign is optional (e.g. "Snapshot"5 = +5)
-    // Default sign is "+" when omitted.
+    // Helper: match a value where the sign is optional (e.g. "Snapshot"5 = +5).
+    // Default sign is "+" when omitted. 全ての出現を合算する。
     function matchOptionalSign(pattern) {
-        const re = new RegExp(pattern, 'i');
-        const m = text.match(re);
-        if (!m) return 0;
-        const sign = m[1] === '-' ? -1 : 1;
-        return sign * parseInt(m[2], 10);
+        const re = new RegExp(pattern, 'gi');
+        let total = 0;
+        for (const m of text.matchAll(re)) {
+            const sign = m[1] === '-' ? -1 : 1;
+            total += sign * parseInt(m[2], 10);
+        }
+        return total;
     }
 
     // Helper: set value only if non-zero

--- a/web/test/equip-stats-extraction.test.js
+++ b/web/test/equip-stats-extraction.test.js
@@ -1,0 +1,129 @@
+// extractAllStats の抽出ロジック検証。
+//
+// 主な対象:
+//   1. Unity Ranking (例: "Unity Ranking: Evasion+15～20") の最大値が
+//      ベースの同名ステに合算されること
+//   2. Pet/Avatar/Wyvern/Automaton セクションの効果がキャラ側に混入しないこと
+//
+// 実行: node web/test/equip-stats-extraction.test.js
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const { extractAllStats } = require('../js/equip-stats.js');
+
+const items = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'data', 'items.json'), 'utf8')
+).items;
+const itemById = Object.fromEntries(items.map((it) => [it.id, it]));
+
+let pass = 0;
+let fail = 0;
+function check(label, got, expected) {
+    if (got === expected) {
+        console.log(`  PASS  ${label}: ${got}`);
+        pass++;
+    } else {
+        console.log(`  FAIL  ${label}: got ${got}, expected ${expected}`);
+        fail++;
+    }
+}
+function statsOf(id) {
+    const desc = itemById[id]?.description_en;
+    assert(desc, `id=${id} not found in items.json`);
+    return extractAllStats(desc);
+}
+
+console.log('=== Unity Ranking ベース合算 ===');
+{
+    // ヒポメネソックス+1: Evasion+71 + Unity Ranking: Evasion+15～20 → 91
+    const s = statsOf(27410);
+    check('ヒポメネソックス+1 evasion (71+20)', s.evasion, 91);
+}
+{
+    // ガズブレスレット+1: Accuracy+31 + Unity Ranking: Accuracy+10～15 → 46
+    const s = statsOf(27151);
+    check('ガズブレスレット+1 accuracy (31+15)', s.accuracy, 46);
+}
+
+console.log('\n=== Pet/Avatar/Wyvern/Automaton セクション除外 ===');
+{
+    // ナレスカフス: 装備 "Magic Atk. Bonus"+13、Avatar: "Magic Atk. Bonus"+8 → 13
+    const s = statsOf(10533);
+    check('ナレスカフス magic_attack (avatar 除外)', s.magic_attack, 13);
+}
+{
+    // テチアンカフス+2: 装備 "Magic Atk. Bonus"+7、Avatar: +5 → 7
+    const s = statsOf(10531);
+    check('テチアンカフス+2 magic_attack (avatar 除外)', s.magic_attack, 7);
+}
+{
+    // パンタンケープ: 装備 Attack+15、Automaton: Attack+15 → 15
+    const s = statsOf(16245);
+    check('パンタンケープ attack (automaton 除外)', s.attack, 15);
+}
+{
+    // ＰＮトベ+2: 装備 Accuracy+15 Attack+15、Automaton: Accuracy+15 "Store TP"+10 → 15
+    const s = statsOf(10687);
+    check('ＰＮトベ+2 accuracy (automaton 除外)', s.accuracy, 15);
+    check('ＰＮトベ+2 attack', s.attack, 15);
+    // Store TP は Automaton 専用なので 0
+    check('ＰＮトベ+2 store_tp (automaton のみ → 0)', s.store_tp ?? 0, 0);
+}
+{
+    // モエパパストーン: 装備 Haste+5%、Pet: Haste+5% → 5
+    const s = statsOf(10817);
+    check('モエパパストーン haste_pct (pet 除外)', s.haste_pct, 5);
+}
+{
+    // ＰＮダスタナ+2: 装備 Haste+4%、Automaton: Haste+4% "Subtle Blow"+5 → 4
+    const s = statsOf(10707);
+    check('ＰＮダスタナ+2 haste_pct (automaton 除外)', s.haste_pct, 4);
+    check('ＰＮダスタナ+2 subtle_blow (automaton のみ → 0)', s.subtle_blow ?? 0, 0);
+}
+{
+    // アスプロピアス (id=26119) ベース description:
+    //   "Pet: Accuracy+15\nRanged Accuracy+15\nMagic Accuracy+15"
+    // 3 行ともペット用 stats (Pet: 行が折り返しで続いている)。
+    // キャラ側に魔命/飛命 +15 が乗るのは augment 経由 (本体には乗らない)。
+    const s = statsOf(26119);
+    check('アスプロピアス accuracy (Pet 専用 → 0)', s.accuracy ?? 0, 0);
+    check('アスプロピアス ranged_accuracy (Pet 専用 → 0)', s.ranged_accuracy ?? 0, 0);
+    check('アスプロピアス magic_accuracy (Pet 専用 → 0)', s.magic_accuracy ?? 0, 0);
+    check('アスプロピアス hp (キャラ用)', s.hp, 100);
+    check('アスプロピアス haste_pct (キャラ用)', s.haste_pct, 5);
+}
+{
+    // メランリング (id=26234) も同様の構造 (Pet: が折り返し続行)
+    const s = statsOf(26234);
+    check('メランリング accuracy (Pet 専用 → 0)', s.accuracy ?? 0, 0);
+    check('メランリング ranged_accuracy (Pet 専用 → 0)', s.ranged_accuracy ?? 0, 0);
+    check('メランリング magic_accuracy (Pet 専用 → 0)', s.magic_accuracy ?? 0, 0);
+    check('メランリング mp (キャラ用)', s.mp, 30);
+    check('メランリング damage_taken_pct (キャラ用)', s.damage_taken_pct, -10);
+}
+{
+    // ＰＩトベ+4 (id=23980) Automaton 折り返し続行の例:
+    //   "Automaton: Accuracy+55 Attack+70 Ranged Accuracy+55 Ranged Attack+70
+    //    Magic Accuracy+55 \"Store TP\"+15"
+    // 2 行目もすべて Automaton 用なのでキャラ集計には混入しない。
+    const s = statsOf(23980);
+    check('ＰＩトベ+4 magic_accuracy (Automaton 続行除外)', s.magic_accuracy, 45);
+    check('ＰＩトベ+4 store_tp (Automaton 専用 → 0)', s.store_tp ?? 0, 0);
+}
+
+console.log('\n=== 既存挙動の維持 (回帰チェック) ===');
+{
+    // ニビルナイフ (id=20600): 既存の単一ステ抽出が壊れないこと
+    const s = statsOf(20600);
+    check('ニビルナイフ str (該当無し → undefined)', s.str ?? 0, 0);
+    check('ニビルナイフ dex (+5)', s.dex, 5);
+    check('ニビルナイフ agi (+5)', s.agi, 5);
+    check('ニビルナイフ chr (+5)', s.chr, 5);
+    check('ニビルナイフ evasion (+29)', s.evasion, 29);
+}
+
+console.log('');
+console.log(`${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

`web/js/equip-stats.js` の `extractAllStats` で発生していた 2 件のバグを修正。

### 1. Unity Ranking 効果がベース同名ステに重畳しないバグ

`matchSigned` / `matchOptionalSign` が `String.match` を非グローバル (最初のマッチのみ) で呼んでいたため、Unity Ranking 正規化後に同名ステが 2 回出現するケースで 2 つ目が無視されていた。

例: ヒポメネソックス+1 (id=27410)
- description: `Evasion+71 ... Unity Ranking: Evasion+15～20`
- Unity 正規化後: `Evasion+71 ... Evasion+20`
- 旧: `evasion=71` (Unity 分 +20 が無視) → 新: `evasion=91` ✓

→ `matchAll` (`/g`) で全マッチを合算するよう変更。

### 2. /g 化に伴う Avatar/Wyvern/Automaton ペット効果のキャラ混入を防止

旧実装は `Pet:` プレフィックスのみ strip していたため、`Avatar:` / `Wyvern:` / `Automaton:` 配下のペット用効果は素通りしていた。非グローバルマッチ時はキャラ側の同名ステが先に拾われて偶然問題化していなかったが、`/g` 化すると合算されてしまう。

例: テチアンカフス+2 (id=10531)
- description: `"Magic Atk. Bonus"+7 ... Avatar: "Magic Atk. Bonus"+5`
- 旧: `magic_attack=7` (キャラのみ偶然マッチ) → /g のまま: 12 (誤) → strip 拡張で 7 ✓

→ strip パターンを `(?:Pet|Avatar|Wyvern|Automaton):[^:]*` に拡張。内側 `[^:]*` は変更せず (Pet 行は折り返し続行することがあり、すべてペット用 stats のため)。

## Test plan

新規テストファイル `web/test/equip-stats-extraction.test.js` を追加 (28 ケース):

- Unity Ranking 重畳: ヒポメネソックス+1, ガズブレスレット+1
- ペット系 strip: ナレスカフス, テチアンカフス+2, パンタンケープ, ＰＮトベ+2, モエパパストーン, ＰＮダスタナ+2
- 折り返し続行行: アスプロピアス, メランリング, ＰＩトベ+4
- 回帰: ニビルナイフ

- [x] `node web/test/equip-stats-extraction.test.js` 28/28 passed
- [x] `node web/test/skillchain-bonus.test.js` 27/27 passed (回帰)
- [x] `node web/test/ws-damage-sam-elemental.test.js` PASS (回帰)