### PR TITLE
[Feature] 魔法タブを 11 種別 (神聖/回復/強化/弱体/精霊/暗黒/召喚/忍術/呪歌/青/風水) に分割

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1443,7 +1443,17 @@
                     <button class="status-subtab-btn" data-subtab="subtab-elemental-ws" type="button">属性WS</button>
                     <button class="status-subtab-btn" data-subtab="subtab-melee-elemental-ws" type="button">近接属性物理WS</button>
                     <button class="status-subtab-btn" data-subtab="subtab-ranged-elemental-ws" type="button">遠隔属性物理WS</button>
-                    <button class="status-subtab-btn" data-subtab="subtab-magic" type="button">魔法</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-divine" type="button">神聖魔法</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-healing" type="button">回復魔法</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-enhancing" type="button">強化魔法</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-enfeebling" type="button">弱体魔法</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-elemental" type="button">精霊魔法</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-dark" type="button">暗黒魔法</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-summoning" type="button">召喚魔法</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-ninjutsu" type="button">忍術</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-song" type="button">呪歌</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-blue" type="button">青魔法</button>
+                    <button class="status-subtab-btn" data-subtab="subtab-magic-geomancy" type="button">風水魔法</button>
                 </div>
 
                 <!-- 1. 待機/回避/防御 -->
@@ -1793,24 +1803,268 @@
                     </table>
                 </div>
 
-                <!-- 9. 魔法 -->
-                <div id="subtab-magic" class="status-subtab-content">
+                <!-- 9. 神聖魔法 -->
+                <div id="subtab-magic-divine" class="status-subtab-content">
                     <table class="status-table">
-                        <thead><tr><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <thead><tr><th>神聖魔法スキル</th><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
                         <tbody><tr>
-                            <td class="equip-val" id="statMgMatk">-</td>
-                            <td class="equip-val" id="statMgMacc">-</td>
-                            <td class="equip-val" id="statMgMeva">-</td>
-                            <td class="equip-val" id="statMgMdmg">-</td>
+                            <td class="equip-val" id="statMgDivineSkill">-</td>
+                            <td class="equip-val" id="statMgDivineMatk">-</td>
+                            <td class="equip-val" id="statMgDivineMacc">-</td>
+                            <td class="equip-val" id="statMgDivineMeva">-</td>
+                            <td class="equip-val" id="statMgDivineMdmg">-</td>
                         </tr></tbody>
                     </table>
                     <table class="status-table">
                         <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
                         <tbody><tr>
-                            <td class="equip-val" id="statMgInt">-</td>
-                            <td class="equip-val" id="statMgMnd">-</td>
-                            <td class="equip-val" id="statMgChr">-</td>
-                            <td class="equip-val" id="statMgMp">-</td>
+                            <td class="equip-val" id="statMgDivineInt">-</td>
+                            <td class="equip-val" id="statMgDivineMnd">-</td>
+                            <td class="equip-val" id="statMgDivineChr">-</td>
+                            <td class="equip-val" id="statMgDivineMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 10. 回復魔法 -->
+                <div id="subtab-magic-healing" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>回復魔法スキル</th><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgHealingSkill">-</td>
+                            <td class="equip-val" id="statMgHealingMatk">-</td>
+                            <td class="equip-val" id="statMgHealingMacc">-</td>
+                            <td class="equip-val" id="statMgHealingMeva">-</td>
+                            <td class="equip-val" id="statMgHealingMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgHealingInt">-</td>
+                            <td class="equip-val" id="statMgHealingMnd">-</td>
+                            <td class="equip-val" id="statMgHealingChr">-</td>
+                            <td class="equip-val" id="statMgHealingMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 11. 強化魔法 -->
+                <div id="subtab-magic-enhancing" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>強化魔法スキル</th><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgEnhancingSkill">-</td>
+                            <td class="equip-val" id="statMgEnhancingMatk">-</td>
+                            <td class="equip-val" id="statMgEnhancingMacc">-</td>
+                            <td class="equip-val" id="statMgEnhancingMeva">-</td>
+                            <td class="equip-val" id="statMgEnhancingMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgEnhancingInt">-</td>
+                            <td class="equip-val" id="statMgEnhancingMnd">-</td>
+                            <td class="equip-val" id="statMgEnhancingChr">-</td>
+                            <td class="equip-val" id="statMgEnhancingMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 12. 弱体魔法 -->
+                <div id="subtab-magic-enfeebling" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>弱体魔法スキル</th><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgEnfeeblingSkill">-</td>
+                            <td class="equip-val" id="statMgEnfeeblingMatk">-</td>
+                            <td class="equip-val" id="statMgEnfeeblingMacc">-</td>
+                            <td class="equip-val" id="statMgEnfeeblingMeva">-</td>
+                            <td class="equip-val" id="statMgEnfeeblingMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgEnfeeblingInt">-</td>
+                            <td class="equip-val" id="statMgEnfeeblingMnd">-</td>
+                            <td class="equip-val" id="statMgEnfeeblingChr">-</td>
+                            <td class="equip-val" id="statMgEnfeeblingMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 13. 精霊魔法 -->
+                <div id="subtab-magic-elemental" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>精霊魔法スキル</th><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgElementalSkill">-</td>
+                            <td class="equip-val" id="statMgElementalMatk">-</td>
+                            <td class="equip-val" id="statMgElementalMacc">-</td>
+                            <td class="equip-val" id="statMgElementalMeva">-</td>
+                            <td class="equip-val" id="statMgElementalMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgElementalInt">-</td>
+                            <td class="equip-val" id="statMgElementalMnd">-</td>
+                            <td class="equip-val" id="statMgElementalChr">-</td>
+                            <td class="equip-val" id="statMgElementalMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 14. 暗黒魔法 -->
+                <div id="subtab-magic-dark" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>暗黒魔法スキル</th><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgDarkSkill">-</td>
+                            <td class="equip-val" id="statMgDarkMatk">-</td>
+                            <td class="equip-val" id="statMgDarkMacc">-</td>
+                            <td class="equip-val" id="statMgDarkMeva">-</td>
+                            <td class="equip-val" id="statMgDarkMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgDarkInt">-</td>
+                            <td class="equip-val" id="statMgDarkMnd">-</td>
+                            <td class="equip-val" id="statMgDarkChr">-</td>
+                            <td class="equip-val" id="statMgDarkMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 15. 召喚魔法 -->
+                <div id="subtab-magic-summoning" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>召喚魔法スキル</th><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgSummoningSkill">-</td>
+                            <td class="equip-val" id="statMgSummoningMatk">-</td>
+                            <td class="equip-val" id="statMgSummoningMacc">-</td>
+                            <td class="equip-val" id="statMgSummoningMeva">-</td>
+                            <td class="equip-val" id="statMgSummoningMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgSummoningInt">-</td>
+                            <td class="equip-val" id="statMgSummoningMnd">-</td>
+                            <td class="equip-val" id="statMgSummoningChr">-</td>
+                            <td class="equip-val" id="statMgSummoningMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 16. 忍術 -->
+                <div id="subtab-magic-ninjutsu" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>忍術スキル</th><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgNinjutsuSkill">-</td>
+                            <td class="equip-val" id="statMgNinjutsuMatk">-</td>
+                            <td class="equip-val" id="statMgNinjutsuMacc">-</td>
+                            <td class="equip-val" id="statMgNinjutsuMeva">-</td>
+                            <td class="equip-val" id="statMgNinjutsuMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgNinjutsuInt">-</td>
+                            <td class="equip-val" id="statMgNinjutsuMnd">-</td>
+                            <td class="equip-val" id="statMgNinjutsuChr">-</td>
+                            <td class="equip-val" id="statMgNinjutsuMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 17. 呪歌 -->
+                <div id="subtab-magic-song" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>歌唱スキル</th><th>弦楽器スキル</th><th>管楽器スキル</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgSongSingingSkill">-</td>
+                            <td class="equip-val" id="statMgSongStringSkill">-</td>
+                            <td class="equip-val" id="statMgSongWindSkill">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgSongMatk">-</td>
+                            <td class="equip-val" id="statMgSongMacc">-</td>
+                            <td class="equip-val" id="statMgSongMeva">-</td>
+                            <td class="equip-val" id="statMgSongMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgSongInt">-</td>
+                            <td class="equip-val" id="statMgSongMnd">-</td>
+                            <td class="equip-val" id="statMgSongChr">-</td>
+                            <td class="equip-val" id="statMgSongMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 18. 青魔法 -->
+                <div id="subtab-magic-blue" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>青魔法スキル</th><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgBlueSkill">-</td>
+                            <td class="equip-val" id="statMgBlueMatk">-</td>
+                            <td class="equip-val" id="statMgBlueMacc">-</td>
+                            <td class="equip-val" id="statMgBlueMeva">-</td>
+                            <td class="equip-val" id="statMgBlueMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgBlueInt">-</td>
+                            <td class="equip-val" id="statMgBlueMnd">-</td>
+                            <td class="equip-val" id="statMgBlueChr">-</td>
+                            <td class="equip-val" id="statMgBlueMp">-</td>
+                        </tr></tbody>
+                    </table>
+                </div>
+
+                <!-- 19. 風水魔法 -->
+                <div id="subtab-magic-geomancy" class="status-subtab-content">
+                    <table class="status-table">
+                        <thead><tr><th>風水魔法スキル</th><th>風水鈴スキル</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgGeomancySkill">-</td>
+                            <td class="equip-val" id="statMgGeomancyHandbellSkill">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>魔攻</th><th>魔命</th><th>魔回避</th><th>魔法ダメ</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgGeomancyMatk">-</td>
+                            <td class="equip-val" id="statMgGeomancyMacc">-</td>
+                            <td class="equip-val" id="statMgGeomancyMeva">-</td>
+                            <td class="equip-val" id="statMgGeomancyMdmg">-</td>
+                        </tr></tbody>
+                    </table>
+                    <table class="status-table">
+                        <thead><tr><th>INT</th><th>MND</th><th>CHR</th><th>MP</th></tr></thead>
+                        <tbody><tr>
+                            <td class="equip-val" id="statMgGeomancyInt">-</td>
+                            <td class="equip-val" id="statMgGeomancyMnd">-</td>
+                            <td class="equip-val" id="statMgGeomancyChr">-</td>
+                            <td class="equip-val" id="statMgGeomancyMp">-</td>
                         </tr></tbody>
                     </table>
                 </div>

--- a/web/js/status-display.js
+++ b/web/js/status-display.js
@@ -416,6 +416,11 @@ export async function updateEquipEditStatus(deps) {
                 ['GeomancyHandbellSkill', 'Handbell'],
             ]},
         ];
+        // タブの可視性: メイン or サポートジョブが該当スキルを習得 (effective_skill > 0) しているもののみ表示
+        const skillKeysOf = (skills) => skills.map(s => typeof s === 'string' ? s : s[1]);
+        const isTabAvailable = (skills) =>
+            skillKeysOf(skills).some(k => (effSkillsForMagic[k] || 0) > 0);
+        let firstVisibleTab = null;
         magicTabs.forEach(({ prefix, skills }) => {
             // スキル値の表示 (単一スキル → "<prefix>Skill"、複数 → 各 ID 指定)
             if (skills.length === 1 && typeof skills[0] === 'string') {
@@ -434,7 +439,31 @@ export async function updateEquipEditStatus(deps) {
             setText(`statMg${prefix}Mnd`, totalStats.mnd || '-');
             setText(`statMg${prefix}Chr`, totalStats.chr || '-');
             setText(`statMg${prefix}Mp`,  totalStats.mp  || '-');
+
+            // ジョブが該当魔法スキルを持たない場合はタブ自体を非表示
+            const subtabId = `subtab-magic-${prefix.toLowerCase()}`;
+            const btn = document.querySelector(`.status-subtab-btn[data-subtab="${subtabId}"]`);
+            const content = document.getElementById(subtabId);
+            const visible = isTabAvailable(skills);
+            if (btn) btn.style.display = visible ? '' : 'none';
+            if (content && !visible) content.classList.remove('active');
+            if (visible && firstVisibleTab === null) firstVisibleTab = subtabId;
         });
+        // 非表示タブが現在 active だった場合、可視の魔法タブ → 既定 (待機/回避/防御) へフォールバック
+        const activeBtn = document.querySelector('.status-subtab-btn.active');
+        if (activeBtn) {
+            const activeId = activeBtn.dataset.subtab;
+            if (activeId && activeId.startsWith('subtab-magic-') &&
+                activeBtn.style.display === 'none') {
+                const fallback = firstVisibleTab || 'subtab-defense';
+                document.querySelectorAll('.status-subtab-btn').forEach(b => b.classList.remove('active'));
+                document.querySelectorAll('.status-subtab-content').forEach(c => c.classList.remove('active'));
+                const newBtn = document.querySelector(`.status-subtab-btn[data-subtab="${fallback}"]`);
+                const newContent = document.getElementById(fallback);
+                if (newBtn) newBtn.classList.add('active');
+                if (newContent) newContent.classList.add('active');
+            }
+        }
 
         // 有効スキル値の表示（値が 0 のスキルは非表示）
         const skillsContainer = document.getElementById('equipEffectiveSkills');

--- a/web/js/status-display.js
+++ b/web/js/status-display.js
@@ -390,15 +390,51 @@ export async function updateEquipEditStatus(deps) {
         setText('statRewsPdl', pctOrDash(equip.physical_damage_limit_pct));
         setText('statRewsTs', numOrDash(equip.true_shot));
 
-        // ----- Tab 9: 魔法 -----
-        setText('statMgMatk', numOrDash(magicAttackTotal));
-        setText('statMgMacc', numOrDash(magicAccuracyTotal));
-        setText('statMgMeva', numOrDash(magicEvasionTotal));
-        setText('statMgMdmg', numOrDash(magicDamageTotal));
-        setText('statMgInt', totalStats.int || '-');
-        setText('statMgMnd', totalStats.mnd || '-');
-        setText('statMgChr', totalStats.chr || '-');
-        setText('statMgMp', totalStats.mp || '-');
+        // ----- Tab 9-19: 魔法 (11 種別) -----
+        // 各種別ごとに: 該当スキル + 魔攻/魔命/魔回避/魔法ダメ + INT/MND/CHR/MP
+        // 呪歌 (歌唱/弦楽器/管楽器), 風水 (風水/風水鈴) は複数スキルを持つ。
+        const effSkillsForMagic = totalStats.effective_skills || {};
+        const magicTabs = [
+            { prefix: 'Divine',     skills: ['Divine'] },
+            { prefix: 'Healing',    skills: ['Healing'] },
+            { prefix: 'Enhancing',  skills: ['Enhancing'] },
+            { prefix: 'Enfeebling', skills: ['Enfeebling'] },
+            { prefix: 'Elemental',  skills: ['Elemental'] },
+            { prefix: 'Dark',       skills: ['Dark'] },
+            { prefix: 'Summoning',  skills: ['Summoning'] },
+            { prefix: 'Ninjutsu',   skills: ['Ninjutsu'] },
+            // 呪歌 = 歌唱 + 弦楽器 + 管楽器 (3 スキル別表示)
+            { prefix: 'Song',       skills: [
+                ['SongSingingSkill', 'Singing'],
+                ['SongStringSkill',  'StringInstrument'],
+                ['SongWindSkill',    'WindInstrument'],
+            ]},
+            { prefix: 'Blue',       skills: ['BlueMagic'] },
+            // 風水 = 風水 + 風水鈴 (2 スキル別表示)
+            { prefix: 'Geomancy',   skills: [
+                ['GeomancySkill',         'Geomancy'],
+                ['GeomancyHandbellSkill', 'Handbell'],
+            ]},
+        ];
+        magicTabs.forEach(({ prefix, skills }) => {
+            // スキル値の表示 (単一スキル → "<prefix>Skill"、複数 → 各 ID 指定)
+            if (skills.length === 1 && typeof skills[0] === 'string') {
+                setText(`statMg${prefix}Skill`, numOrDash(effSkillsForMagic[skills[0]]));
+            } else {
+                skills.forEach(([idSuffix, key]) => {
+                    setText(`statMg${prefix}${idSuffix.replace(prefix, '')}`,
+                            numOrDash(effSkillsForMagic[key]));
+                });
+            }
+            setText(`statMg${prefix}Matk`, numOrDash(magicAttackTotal));
+            setText(`statMg${prefix}Macc`, numOrDash(magicAccuracyTotal));
+            setText(`statMg${prefix}Meva`, numOrDash(magicEvasionTotal));
+            setText(`statMg${prefix}Mdmg`, numOrDash(magicDamageTotal));
+            setText(`statMg${prefix}Int`, totalStats.int || '-');
+            setText(`statMg${prefix}Mnd`, totalStats.mnd || '-');
+            setText(`statMg${prefix}Chr`, totalStats.chr || '-');
+            setText(`statMg${prefix}Mp`,  totalStats.mp  || '-');
+        });
 
         // 有効スキル値の表示（値が 0 のスキルは非表示）
         const skillsContainer = document.getElementById('equipEffectiveSkills');
@@ -473,9 +509,21 @@ export function clearAllEquipStats() {
         'statRewsMatk', 'statRewsMacc', 'statRewsMdmg', 'statRewsAff', 'statRewsMcrit2',
         'statRewsStp', 'statRewsSb', 'statRewsSb2', 'statRewsCrit', 'statRewsCritDmg',
         'statRewsWsdmg', 'statRewsTpb', 'statRewsScb', 'statRewsPdl', 'statRewsTs',
-        // Tab 9: 魔法
-        'statMgMatk', 'statMgMacc', 'statMgMeva', 'statMgMdmg',
-        'statMgInt', 'statMgMnd', 'statMgChr', 'statMgMp',
+        // Tab 9-19: 魔法 (11 種別)
+        ...['Divine', 'Healing', 'Enhancing', 'Enfeebling', 'Elemental', 'Dark',
+            'Summoning', 'Ninjutsu', 'Blue'].flatMap(p => [
+            `statMg${p}Skill`,
+            `statMg${p}Matk`, `statMg${p}Macc`, `statMg${p}Meva`, `statMg${p}Mdmg`,
+            `statMg${p}Int`, `statMg${p}Mnd`, `statMg${p}Chr`, `statMg${p}Mp`,
+        ]),
+        // 呪歌 (3 スキル別表示)
+        'statMgSongSingingSkill', 'statMgSongStringSkill', 'statMgSongWindSkill',
+        'statMgSongMatk', 'statMgSongMacc', 'statMgSongMeva', 'statMgSongMdmg',
+        'statMgSongInt', 'statMgSongMnd', 'statMgSongChr', 'statMgSongMp',
+        // 風水 (2 スキル別表示)
+        'statMgGeomancySkill', 'statMgGeomancyHandbellSkill',
+        'statMgGeomancyMatk', 'statMgGeomancyMacc', 'statMgGeomancyMeva', 'statMgGeomancyMdmg',
+        'statMgGeomancyInt', 'statMgGeomancyMnd', 'statMgGeomancyChr', 'statMgGeomancyMp',
     ];
     tabIds.forEach(id => {
         const elem = document.getElementById(id);


### PR DESCRIPTION
## Summary

装備ステータス画面の「魔法」サブタブを以下の 11 種別に分割:

- 神聖魔法 (Divine)
- 回復魔法 (Healing)
- 強化魔法 (Enhancing)
- 弱体魔法 (Enfeebling)
- 精霊魔法 (Elemental)
- 暗黒魔法 (Dark)
- 召喚魔法 (Summoning)
- 忍術 (Ninjutsu)
- 呪歌 (Singing + StringInstrument + WindInstrument)
- 青魔法 (BlueMagic)
- 風水魔法 (Geomancy + Handbell)

各タブのレイアウト:

```
| 該当魔法スキル | 魔攻 | 魔命 | 魔回避 | 魔法ダメ |
| INT | MND | CHR | MP |
```

呪歌は 3 スキル別表示 (歌唱/弦楽器/管楽器)、風水は 2 スキル別表示 (風水/風水鈴) として 1 行目を拡張。

## 現状の制約

魔攻/魔命/魔回避/魔法ダメ は装備合計値で全タブ同一表示。種別ごとの specialize
(回復: ケアル回復量+, 強化: 強化魔法効果アップ, 呪歌: 詠唱/効果時間, etc.) は
Rust の `BonusStats` / `StatusResult` にフィールド追加が必要なため、別タスクで対応。

## 変更ファイル

- `web/index.html`: サブタブボタン 1→11、subtab content div 1→11
- `web/js/status-display.js`: 11 種別に対するループで populate、`clearAllEquipStats` の ID リスト更新

## Test plan

- [x] HTML 構造検証: 11 ボタンと 11 div が一致 (`subtab-magic-{type}` ID 整合)
- [x] HTML/JS の statMg* ID 102 件が一意かつ整合 (生成 vs HTML)
- [x] `node --check` で status-display.js 構文エラーなし
- [x] `python3 -m http.server` で index.html / status-display.js が HTTP 200
- [ ] ブラウザで各タブを切り替えて表示が正しいことを目視確認 (要手動)