### PR TITLE
[Feature] 「魔法スキル+N」装備を 14 種すべての魔法スキルに加算

### DIFF
--- a/web/js/constants.js
+++ b/web/js/constants.js
@@ -72,6 +72,8 @@ export const AUGMENT_JA_TO_EN = [
     ['モクシャII', '"Subtle Blow II"'],
     ['モクシャ', '"Subtle Blow"'],
     ['魔法ダメージ', 'Magic Damage'],
+    // 全魔法スキル一括加算 (extractSkillBonuses で 14 種に展開される)
+    ['魔法スキル', 'Magic skills'],
     ['被ダメージ', 'Damage taken'],
     ['ストアTP', '"Store TP"'],
     ['TPボーナス', '"TP Bonus"'],

--- a/web/js/equip-stats.js
+++ b/web/js/equip-stats.js
@@ -322,6 +322,23 @@ function extractSkillBonuses(descriptionEn) {
     matchAllRegex(/(?<![A-Za-z])Geomancy(?:\s+skill)?\s*([+-])\s*(\d+)/gi, 'Geomancy');
     matchAllRegex(/(?<![A-Za-z])Handbell(?:\s+skill)?\s*([+-])\s*(\d+)/gi, 'Handbell');
 
+    // 全魔法スキル一括加算: "Magic skills +N" / "All magic skills +N"
+    // 14 種すべての魔法スキルに +N 加算する。
+    // 例: インカンタートルク "Magic skills +10"、スティキニリング "All magic skills +5"
+    // 注: "Healing magic skill +5" 等は単数形 (skill) なのでマッチしない。
+    const ALL_MAGIC_SKILLS = [
+        'Divine', 'Healing', 'Enhancing', 'Enfeebling', 'Elemental', 'Dark',
+        'Summoning', 'Ninjutsu', 'Singing', 'StringInstrument', 'WindInstrument',
+        'BlueMagic', 'Geomancy', 'Handbell',
+    ];
+    for (const m of text.matchAll(/(?<![A-Za-z])(?:All\s+)?Magic\s+skills\s*([+-])\s*(\d+)/gi)) {
+        const sign = m[1] === '-' ? -1 : 1;
+        const v = sign * parseInt(m[2], 10);
+        for (const k of ALL_MAGIC_SKILLS) {
+            add(k, v);
+        }
+    }
+
     return result;
 }
 

--- a/web/test/equip-stats-extraction.test.js
+++ b/web/test/equip-stats-extraction.test.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-const { extractAllStats } = require('../js/equip-stats.js');
+const { extractAllStats, extractSkillBonuses } = require('../js/equip-stats.js');
 
 const items = JSON.parse(
     fs.readFileSync(path.join(__dirname, '..', 'data', 'items.json'), 'utf8')
@@ -113,6 +113,31 @@ console.log('\n=== Pet/Avatar/Wyvern/Automaton セクション除外 ===');
     check('ＰＩトベ+4 store_tp (Automaton 専用 → 0)', s.store_tp ?? 0, 0);
 }
 
+console.log('\n=== 全魔法スキル一括加算 (Magic skills +N) ===');
+{
+    // インカンタートルク (id=26016): "Magic skills +10" → 14 種すべてに +10
+    const sb = extractSkillBonuses(itemById[26016].description_en);
+    const ALL_MAGIC = ['Divine','Healing','Enhancing','Enfeebling','Elemental','Dark',
+                       'Summoning','Ninjutsu','Singing','StringInstrument','WindInstrument',
+                       'BlueMagic','Geomancy','Handbell'];
+    for (const k of ALL_MAGIC) check(`インカンタートルク ${k} (+10)`, sb[k] ?? 0, 10);
+}
+{
+    // スティキニリング+1 (id=26184): "All magic skills +8" → 14 種すべてに +8
+    const sb = extractSkillBonuses(itemById[26184].description_en);
+    check('スティキニリング+1 Healing (+8)', sb.Healing ?? 0, 8);
+    check('スティキニリング+1 Geomancy (+8)', sb.Geomancy ?? 0, 8);
+    check('スティキニリング+1 BlueMagic (+8)', sb.BlueMagic ?? 0, 8);
+}
+{
+    // ホクスニトルク (id=26043): "Combat skills +30 / Magic skills +30 / Slow+5%"
+    // 戦闘スキル+30 は対象外 (魔法スキル+30 のみ 14 種に加算)
+    const sb = extractSkillBonuses(itemById[26043].description_en);
+    check('ホクスニトルク Divine (+30)', sb.Divine ?? 0, 30);
+    check('ホクスニトルク Ninjutsu (+30)', sb.Ninjutsu ?? 0, 30);
+    check('ホクスニトルク Sword (combat skills は未対応 → 0)', sb.Sword ?? 0, 0);
+}
+
 console.log('\n=== 既存挙動の維持 (回帰チェック) ===');
 {
     // ニビルナイフ (id=20600): 既存の単一ステ抽出が壊れないこと
@@ -122,6 +147,10 @@ console.log('\n=== 既存挙動の維持 (回帰チェック) ===');
     check('ニビルナイフ agi (+5)', s.agi, 5);
     check('ニビルナイフ chr (+5)', s.chr, 5);
     check('ニビルナイフ evasion (+29)', s.evasion, 29);
+    // 単一魔法スキル装備が誤って 14 種にばらまかれないこと
+    const sb = extractSkillBonuses(itemById[20600].description_en);
+    check('ニビルナイフ Dagger skill (+242 既存)', sb.Dagger ?? 0, 242);
+    check('ニビルナイフ Healing (魔法スキル+対象外 → 0)', sb.Healing ?? 0, 0);
 }
 
 console.log('');


### PR DESCRIPTION
## Summary

`extractSkillBonuses` でジェネリックな「Magic skills +N」 / 「All magic skills +N」表記を検出した場合、14 種すべての魔法スキル (Divine, Healing, Enhancing, Enfeebling, Elemental, Dark, Summoning, Ninjutsu, Singing, StringInstrument, WindInstrument, BlueMagic, Geomancy, Handbell) に +N 加算するように対応。

## 対象アイテム (items.json から検出)

| id | 装備 | EN 表記 | 追加効果 |
|---|---|---|---|
| 26016 | インカンタートルク | `Magic skills +10` | 14 種全部に +10 |
| 26043 | ホクスニトルク | `Magic skills +30` | 14 種全部に +30 (Combat skills+30 は未対応) |
| 26183 | スティキニリング | `All magic skills +5` | 14 種全部に +5 |
| 26184 | スティキニリング+1 | `All magic skills +8` | 14 種全部に +8 |

## 衝突回避

- 単数形 (`Magic skill +N`) は対象外。`Healing magic skill +5` などの単一スキル抽出 (既存パターン) とは衝突しない
- 正規表現は `(?:All\s+)?Magic\s+skills\s*([+-])\s*(\d+)` (skills は複数形必須)

## 変更ファイル

- `web/js/equip-stats.js`: extractSkillBonuses に generic Magic skills パターン追加
- `web/js/constants.js`: AUGMENT_JA_TO_EN に「魔法スキル」→「Magic skills」追加 (オーグメント記述対応)
- `web/test/equip-stats-extraction.test.js`: テストケース 22 件追加

## Test plan

- [x] `node web/test/equip-stats-extraction.test.js` 50/50 passed
- [x] `node web/test/skillchain-bonus.test.js` 27/27 passed (回帰)
- [x] `node web/test/ws-damage-sam-elemental.test.js` PASS (回帰)