### PR TITLE
[Fix] 装備の属性耐性 / 状態異常レジスト抽出を実データに整合 + テナシティ反映

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1476,7 +1476,7 @@
                         </tr></tbody>
                     </table>
                     <table class="status-table">
-                        <thead><tr><th colspan="8">属性レジスト</th></tr><tr><th>火</th><th>氷</th><th>風</th><th>土</th><th>雷</th><th>水</th><th>光</th><th>闇</th></tr></thead>
+                        <thead><tr><th colspan="8">属性耐性</th></tr><tr><th>火</th><th>氷</th><th>風</th><th>土</th><th>雷</th><th>水</th><th>光</th><th>闇</th></tr></thead>
                         <tbody><tr>
                             <td class="equip-val" id="statDefResFire">-</td>
                             <td class="equip-val" id="statDefResIce">-</td>

--- a/web/js/constants.js
+++ b/web/js/constants.js
@@ -90,6 +90,28 @@ export const AUGMENT_JA_TO_EN = [
     ['風水鈴スキル', 'Handbell skill'],
     // 全魔法スキル一括加算 (extractSkillBonuses で 14 種に展開される)
     ['魔法スキル', 'Magic skills'],
+    // 状態異常レジスト
+    // 順序重要: 「全状態異常のレジスト」を個別レジストより先に置く (汎用パターン後置)
+    ['全状態異常のレジスト', 'Resistance to all status ailments'],
+    // デス/テラーは items.json で「耐性」表記、EN も独自形式 (引用符 + resistance / 引用符なし)
+    ['デス耐性', '"Death" resistance'],
+    ['テラー耐性', 'Terror resistance'],
+    // 残り 14 種: JA「レジストX」 ↔ EN「"Resist X"」 (引用符付き、X は短縮形)
+    ['レジストアムネジア', '"Resist Amnesia"'],
+    ['レジストペトリ', '"Resist Petrify"'],
+    ['レジストパライズ', '"Resist Paralyze"'],
+    ['レジストグラビデ', '"Resist Gravity"'],
+    ['レジストグラビティ', '"Resist Gravity"'],
+    ['レジストサイレス', '"Resist Silence"'],
+    ['レジストスリープ', '"Resist Sleep"'],
+    ['レジストポイズン', '"Resist Poison"'],
+    ['レジストチャーム', '"Resist Charm"'],
+    ['レジストブライン', '"Resist Blind"'],
+    ['レジストカース', '"Resist Curse"'],
+    ['レジストウィルス', '"Resist Virus"'],
+    ['レジストバインド', '"Resist Bind"'],
+    ['レジストスロウ', '"Resist Slow"'],
+    ['レジストスタン', '"Resist Stun"'],
     // 属性耐性 (装備の「耐火+15」等を EN 化)
     // 順序重要: 全耐性 系 → 個別耐性 (個別が「全」の文字列に部分マッチしないが念のため先に置く)
     ['全属性耐性', 'All elemental resistances'],

--- a/web/js/constants.js
+++ b/web/js/constants.js
@@ -91,6 +91,9 @@ export const AUGMENT_JA_TO_EN = [
     // 全魔法スキル一括加算 (extractSkillBonuses で 14 種に展開される)
     ['魔法スキル', 'Magic skills'],
     // 属性耐性 (装備の「耐火+15」等を EN 化)
+    // 順序重要: 全耐性 系 → 個別耐性 (個別が「全」の文字列に部分マッチしないが念のため先に置く)
+    ['全属性耐性', 'All elemental resistances'],
+    ['全耐性', 'All elemental resistances'],
     ['耐火', 'Fire Resistance'],
     ['耐氷', 'Ice Resistance'],
     ['耐風', 'Wind Resistance'],

--- a/web/js/constants.js
+++ b/web/js/constants.js
@@ -90,6 +90,15 @@ export const AUGMENT_JA_TO_EN = [
     ['風水鈴スキル', 'Handbell skill'],
     // 全魔法スキル一括加算 (extractSkillBonuses で 14 種に展開される)
     ['魔法スキル', 'Magic skills'],
+    // 属性耐性 (装備の「耐火+15」等を EN 化)
+    ['耐火', 'Fire Resistance'],
+    ['耐氷', 'Ice Resistance'],
+    ['耐風', 'Wind Resistance'],
+    ['耐土', 'Earth Resistance'],
+    ['耐雷', 'Lightning Resistance'],
+    ['耐水', 'Water Resistance'],
+    ['耐光', 'Light Resistance'],
+    ['耐闇', 'Dark Resistance'],
     ['被ダメージ', 'Damage taken'],
     ['ストアTP', '"Store TP"'],
     ['TPボーナス', '"TP Bonus"'],

--- a/web/js/equip-stats.js
+++ b/web/js/equip-stats.js
@@ -15,6 +15,25 @@ function extractAllStats(descriptionEn) {
     // Normalize literal \n to actual newlines
     let text = descriptionEn.replace(/\\n/g, '\n');
 
+    // FFXI の属性アイコン (private-use Unicode -) を「Fire Resistance」等の
+    // 正規表記に正規化する。items.json の description_en は耐性表記をアイコンで持っており、
+    // そのままでは regex でマッチしないため。
+    // マッピング: =火 / =氷 / =風 / =土
+    //            =雷 / =水 / =光 / =闇
+    const ELEMENT_ICON_MAP = {
+        '': 'Fire Resistance ',
+        '': 'Ice Resistance ',
+        '': 'Wind Resistance ',
+        '': 'Earth Resistance ',
+        '': 'Lightning Resistance ',
+        '': 'Water Resistance ',
+        '': 'Light Resistance ',
+        '': 'Dark Resistance ',
+    };
+    for (const [icon, name] of Object.entries(ELEMENT_ICON_MAP)) {
+        text = text.split(icon).join(name);
+    }
+
     // Unity Ranking ボーナスは最大値を採用してプレフィックスを外す
     // e.g. "Unity Ranking: Attack+10～15" → " Attack+15"
     text = text.replace(

--- a/web/js/equip-stats.js
+++ b/web/js/equip-stats.js
@@ -253,6 +253,20 @@ function extractAllStats(descriptionEn) {
         }
     }
 
+    // === 全属性耐性: 8 属性すべてに加減算 ===
+    // 表記: "All elemental resistances +N" (例: イリダルスタッフ)
+    //       "Resist all elements +N" (例: 霊亀棍)
+    // ※ "Set: Increases all elemental resistances" 等の数値なしの記述は対象外 (regex に +-\d 必須)。
+    const allElementResist = matchSigned(
+        '(?:All\\s+elemental\\s+resistances|Resist\\s+all\\s+elements)\\s*([+-])\\s*(\\d+)'
+    );
+    if (allElementResist !== 0) {
+        for (const elem of ['fire','ice','wind','earth','lightning','water','light','dark']) {
+            const k = `resist_${elem}`;
+            result[k] = (result[k] || 0) + allElementResist;
+        }
+    }
+
     return result;
 }
 

--- a/web/js/equip-stats.js
+++ b/web/js/equip-stats.js
@@ -216,29 +216,46 @@ function extractAllStats(descriptionEn) {
     }
 
     // === 状態異常レジスト ===
-    // 表記揺れ: "Resist Sleep+5" / "Terror resistance +30" / "Status ailment resistance +N"
-    const statusResistMap = [
-        ['sleep', 'Sleep'],
-        ['paralysis', 'Paralysis'],
-        ['bind', 'Bind'],
-        ['silence', 'Silence'],
-        ['gravity', 'Gravity'],
-        ['slow', 'Slow'],
-        ['petrification', 'Petrification'],
-        ['stun', 'Stun'],
-        ['poison', 'Poison'],
-        ['charm', 'Charm'],
-        ['blind', 'Blind'],
-        ['curse', 'Curse'],
-        ['virus', 'Virus'],
-        ['amnesia', 'Amnesia'],
-        ['terror', 'Terror'],
-        ['death', 'Death'],
+    // items.json 実表記:
+    //   通常 14 種: "Resist X"+N (引用符付き、X は短縮形 — Petrify, Paralyze 等)
+    //   Terror:    Terror resistance +N (引用符なし、語順 reverse)
+    //   Death:     Resistance against "Death" +N または "Death" resistance +N
+    const statusResistPatterns = [
+        ['sleep',         '"?Resist Sleep"?'],
+        ['paralysis',     '"?Resist Paralyze"?'],
+        ['bind',          '"?Resist Bind"?'],
+        ['silence',       '"?Resist Silence"?'],
+        ['gravity',       '"?Resist Gravity"?'],
+        ['slow',          '"?Resist Slow"?'],
+        ['petrification', '"?Resist Petrify"?'],
+        ['stun',          '"?Resist Stun"?'],
+        ['poison',        '"?Resist Poison"?'],
+        ['charm',         '"?Resist Charm"?'],
+        ['blind',         '"?Resist Blind"?'],
+        ['curse',         '"?Resist Curse"?'],
+        ['virus',         '"?Resist Virus"?'],
+        ['amnesia',       '"?Resist Amnesia"?'],
+        ['terror',        '(?:Terror resistance|"?Resist Terror"?)'],
+        ['death',         '(?:Resistance against "Death"|"Death" resistance|"?Resist Death"?)'],
     ];
-    for (const [key, en] of statusResistMap) {
-        set(`resist_${key}`, matchSigned(
-            `(?:Resist ${en}|${en} [Rr]esistance)\\s*([+-])\\s*(\\d+)`
-        ));
+    for (const [key, pattern] of statusResistPatterns) {
+        set(`resist_${key}`, matchSigned(`${pattern}\\s*([+-])\\s*(\\d+)`));
+    }
+
+    // === 全状態異常のレジスト (デス耐性を除く 15 種に一括加算) ===
+    // wiki 795.html: 「全状態異常のレジスト効果アップ」はデス耐性を除く全状態異常に作用
+    // EN 表記想定: "Resistance to all status ailments +N" / "All status ailment resistance +N"
+    const allStatusResist = matchSigned(
+        'Resistance to all status ailments\\s*([+-])\\s*(\\d+)'
+    ) || matchSigned(
+        'All status ailment[s]? [Rr]esistance\\s*([+-])\\s*(\\d+)'
+    );
+    if (allStatusResist !== 0) {
+        for (const [key] of statusResistPatterns) {
+            if (key === 'death') continue;
+            const k = `resist_${key}`;
+            result[k] = (result[k] || 0) + allStatusResist;
+        }
     }
 
     // === Weapon stats (colon format) ===

--- a/web/js/status-display.js
+++ b/web/js/status-display.js
@@ -22,6 +22,25 @@ function setText(id, v) {
     if (el) el.textContent = v;
 }
 
+// 状態異常レジストのキー (HTML id `statDefRes*` の小文字 suffix と対応)
+export const STATUS_RESIST_KEYS = [
+    'sleep', 'paralysis', 'bind', 'silence', 'gravity', 'slow',
+    'petrification', 'stun', 'poison', 'charm', 'blind', 'curse',
+    'virus', 'amnesia', 'terror', 'death',
+];
+
+// 装備抽出値 + テナシティ (デス以外) の合算。
+// テナシティ = RUN ジョブ特性。wiki 795.html により「全状態異常のレジスト効果アップ」と同等で
+// デス耐性を除く 15 種に作用。tenacity は 0 を渡せば装備値のみ返る。
+export function combineStatusResist(equipResists, tenacity) {
+    const out = {};
+    for (const st of STATUS_RESIST_KEYS) {
+        const equipVal = equipResists['resist_' + st] || 0;
+        out[st] = st === 'death' ? equipVal : equipVal + (tenacity || 0);
+    }
+    return out;
+}
+
 /**
  * キャラクター + 装備セットの合計ステータスを編集パネルに反映。
  * @param {object} deps
@@ -241,12 +260,13 @@ export async function updateEquipEditStatus(deps) {
             const id = 'statDefRes' + elem.charAt(0).toUpperCase() + elem.slice(1);
             setText(id, numOrDash(equip['resist_' + elem]));
         }
-        // 状態異常レジスト
-        for (const st of ['sleep', 'paralysis', 'bind', 'silence', 'gravity', 'slow',
-                          'petrification', 'stun', 'poison', 'charm', 'blind', 'curse',
-                          'virus', 'amnesia', 'terror', 'death']) {
+        // 状態異常レジスト = 装備抽出 + テナシティ (デス以外 15 種)
+        // テナシティ (RUN ジョブ特性) は wiki 795.html により「全状態異常のレジスト」と同等で
+        // デス耐性を除く 15 種に作用する。
+        const statusResistTotals = combineStatusResist(equip, totalStats.tenacity || 0);
+        for (const [st, total] of Object.entries(statusResistTotals)) {
             const id = 'statDefRes' + st.charAt(0).toUpperCase() + st.slice(1);
-            setText(id, numOrDash(equip['resist_' + st]));
+            setText(id, numOrDash(total));
         }
 
         // ----- Tab 2: オートアタック (近接) -----

--- a/web/test/equip-stats-extraction.test.js
+++ b/web/test/equip-stats-extraction.test.js
@@ -230,6 +230,120 @@ console.log('\n=== JA→EN 変換: 個別魔法スキル名の優先 (regression
     }
 }
 
+console.log('\n=== 状態異常レジスト: 個別装備抽出 ===');
+{
+    // 実 items.json データ (id, ailment-key, expected-value)
+    const cases = [
+        [25788, 'sleep', 90],          // Udug Jacket "Resist Sleep"+90
+        [20887, 'paralysis', 50],      // Dacnomania "Resist Paralyze"+50
+        [26202, 'bind', 17],           // Shneddick Ring +1 "Resist Bind"+17
+        [23759, 'silence', 9],         // Agwu's Cap "Resist Silence"+9
+        [23313, 'gravity', 10],        // Pillager's Poulaines +2 "Resist Gravity"+10
+        [21569, 'slow', 90],           // Chocobo Knife "Resist Slow"+90
+        [20606, 'petrification', 15],  // Anathema Harpe "Resist Petrify"+15 (短縮形)
+        [26029, 'stun', 10],           // Anu Torque "Resist Stun"+10
+        [21787, 'poison', 10],         // Poison Axe +1 "Resist Poison"+10
+        [26245, 'charm', 15],          // Solemnity Cape "Resist Charm"+15
+        [21034, 'amnesia', 25],        // Kunimune "Resist Amnesia"+25
+        [20754, 'death', 15],          // Malfeasance: Resistance against "Death" +15
+        [26973, 'death', 15],          // Samnuha Coat: "Death" resistance +15
+        [28330, 'terror', 30],         // Founder's Greaves: Terror resistance +30
+    ];
+    for (const [id, key, expected] of cases) {
+        const s = statsOf(id);
+        check(`id=${id} resist_${key} (+${expected})`, s[`resist_${key}`] ?? 0, expected);
+    }
+}
+{
+    // items.json に該当装備がない 3 種 (blind/curse/virus) は合成 description で確認
+    const synth = '"Resist Blind"+5 "Resist Curse"+8\n"Resist Virus"+12';
+    const s = extractAllStats(synth);
+    check('合成 "Resist Blind"+5', s.resist_blind ?? 0, 5);
+    check('合成 "Resist Curse"+8', s.resist_curse ?? 0, 8);
+    check('合成 "Resist Virus"+12', s.resist_virus ?? 0, 12);
+}
+{
+    // 引用符なし表記 (custom_description で生 augment 文字列を書いた場合のフォールバック)
+    const s = extractAllStats('Resist Slow+45');
+    check('引用符なし Resist Slow+45', s.resist_slow ?? 0, 45);
+}
+
+console.log('\n=== 状態異常レジスト: 全状態異常レジスト+N (デス除く 15 種) ===');
+{
+    // Staunch Tathlum +1 (id=22279): "Resistance to all status ailments +11"
+    const s = statsOf(22279);
+    const expected15 = ['sleep','paralysis','bind','silence','gravity','slow',
+                        'petrification','stun','poison','charm','blind','curse',
+                        'virus','amnesia','terror'];
+    for (const st of expected15) {
+        check(`Staunch Tathlum+1 resist_${st} (+11)`, s[`resist_${st}`] ?? 0, 11);
+    }
+    check('Staunch Tathlum+1 resist_death (除外 → 0)', s.resist_death ?? 0, 0);
+}
+{
+    // Volte Jupon (id=23717): "Resistance to all status ailments +20" (装備に他のステも多数)
+    const s = statsOf(23717);
+    check('Volte Jupon resist_sleep (+20)', s.resist_sleep ?? 0, 20);
+    check('Volte Jupon resist_terror (+20)', s.resist_terror ?? 0, 20);
+    check('Volte Jupon resist_death (除外 → 0)', s.resist_death ?? 0, 0);
+}
+{
+    // 別表記: "All status ailment resistance +5"
+    const s = extractAllStats('All status ailment resistance +5');
+    check('"All status ailment resistance +5" sleep', s.resist_sleep ?? 0, 5);
+    check('"All status ailment resistance +5" death (除外)', s.resist_death ?? 0, 0);
+}
+{
+    // 個別 + 全状態異常 が同居する場合は両方加算される (実装上 result[k] += allStatusResist)
+    const s = extractAllStats('"Resist Sleep"+5 Resistance to all status ailments +10');
+    check('個別+全 sleep (5+10=15)', s.resist_sleep ?? 0, 15);
+    check('個別+全 paralysis (0+10=10)', s.resist_paralysis ?? 0, 10);
+    check('個別+全 death (除外 → 0)', s.resist_death ?? 0, 0);
+}
+
+console.log('\n=== 状態異常レジスト: テナシティ合算 (status-display.combineStatusResist) ===');
+{
+    // status-display.js は ESM なのでファイルを読み込んで該当ロジックを再現
+    const fs = require('fs');
+    const path = require('path');
+    const sd = fs.readFileSync(path.join(__dirname, '..', 'js', 'status-display.js'), 'utf8');
+    // STATUS_RESIST_KEYS と combineStatusResist 関数を抽出
+    const keysM = sd.match(/export const STATUS_RESIST_KEYS\s*=\s*(\[[\s\S]*?\]);/);
+    const fnM   = sd.match(/export function combineStatusResist\(equipResists, tenacity\) \{([\s\S]*?)\n\}/);
+    assert(keysM && fnM, 'status-display.js から combineStatusResist を抽出できない');
+    const STATUS_RESIST_KEYS = eval(keysM[1]);
+    // 関数本体内では STATUS_RESIST_KEYS を参照しているので、ローカル変数として再定義した上で eval する
+    const combineStatusResist = new Function('equipResists', 'tenacity', `
+        const STATUS_RESIST_KEYS = ${keysM[1]};
+        ${fnM[1]}
+    `);
+
+    // (3) テナシティのみ (RUN Lv99 想定 +15)、装備抽出値 0
+    const t = combineStatusResist({}, 15);
+    for (const st of STATUS_RESIST_KEYS) {
+        if (st === 'death') {
+            check(`テナシティのみ resist_death (除外 → 0)`, t.death, 0);
+        } else {
+            check(`テナシティのみ resist_${st} (+15)`, t[st], 15);
+        }
+    }
+
+    // (4) 装備個別 + 装備全状態異常 + テナシティ の 3 つ複合
+    // 装備抽出: "Resist Sleep"+5 + "Resistance to all status ailments +10"
+    const equip = extractAllStats('"Resist Sleep"+5 Resistance to all status ailments +10');
+    const r = combineStatusResist(equip, 15);
+    check('複合 sleep (5+10+15=30)', r.sleep, 30);
+    check('複合 paralysis (0+10+15=25)', r.paralysis, 25);
+    check('複合 terror (0+10+15=25)', r.terror, 25);
+    check('複合 death (装備抽出 0、テナシティ除外 → 0)', r.death, 0);
+
+    // テナシティ 0 (テナシティ未習得) の場合は装備値のみ
+    const r0 = combineStatusResist(equip, 0);
+    check('テナシティ 0 sleep (5+10=15)', r0.sleep, 15);
+    check('テナシティ 0 paralysis (0+10=10)', r0.paralysis, 10);
+    check('テナシティ 0 death (0)', r0.death, 0);
+}
+
 console.log('\n=== 既存挙動の維持 (回帰チェック) ===');
 {
     // ニビルナイフ (id=20600): 既存の単一ステ抽出が壊れないこと

--- a/web/test/equip-stats-extraction.test.js
+++ b/web/test/equip-stats-extraction.test.js
@@ -158,6 +158,20 @@ console.log('\n=== 属性耐性: 装備のアイコン (private-use Unicode) →
         check(`ウェザリンシールド resist_${e} (-10)`, s[`resist_${e}`] ?? 0, -10);
     }
 }
+{
+    // イリダルスタッフ (id=18632): "All elemental resistances +15" → 8 属性すべてに +15
+    const s = statsOf(18632);
+    for (const e of ['fire','ice','wind','earth','lightning','water','light','dark']) {
+        check(`イリダルスタッフ resist_${e} (全属性 +15)`, s[`resist_${e}`] ?? 0, 15);
+    }
+}
+{
+    // 霊亀棍 (id=21152): "Resist all elements +20" → 8 属性すべてに +20
+    const s = statsOf(21152);
+    for (const e of ['fire','ice','wind','earth','lightning','water','light','dark']) {
+        check(`霊亀棍 resist_${e} (全属性 +20)`, s[`resist_${e}`] ?? 0, 20);
+    }
+}
 
 console.log('\n=== JA→EN 変換: 個別魔法スキル名の優先 (regression for #28) ===');
 {

--- a/web/test/equip-stats-extraction.test.js
+++ b/web/test/equip-stats-extraction.test.js
@@ -138,6 +138,27 @@ console.log('\n=== 全魔法スキル一括加算 (Magic skills +N) ===');
     check('ホクスニトルク Sword (combat skills は未対応 → 0)', sb.Sword ?? 0, 0);
 }
 
+console.log('\n=== 属性耐性: 装備のアイコン (private-use Unicode) → "Fire Resistance" 等の正規化 ===');
+{
+    // フィーバーコラジン (id=10287): description_en に "+30" (耐火+30 を表す)
+    const s = statsOf(10287);
+    check('フィーバーコラジン resist_fire (アイコン正規化 → +30)', s.resist_fire ?? 0, 30);
+}
+{
+    // キャリアーサッシュ (id=10832): 8 属性すべて +15
+    const s = statsOf(10832);
+    for (const e of ['fire','ice','wind','earth','lightning','water','light','dark']) {
+        check(`キャリアーサッシュ resist_${e} (+15)`, s[`resist_${e}`] ?? 0, 15);
+    }
+}
+{
+    // ウェザリンシールド (id=10803): 全属性 -10
+    const s = statsOf(10803);
+    for (const e of ['fire','ice','wind','earth','lightning','water','light','dark']) {
+        check(`ウェザリンシールド resist_${e} (-10)`, s[`resist_${e}`] ?? 0, -10);
+    }
+}
+
 console.log('\n=== JA→EN 変換: 個別魔法スキル名の優先 (regression for #28) ===');
 {
     // 「強化魔法スキル+N」「弱体魔法スキル+N」等の JA を convertAugmentJaToEn で


### PR DESCRIPTION
## Summary

待機/防御/回避 タブの「属性耐性」「状態異常レジスト」が殆ど機能していなかった (アイコン文字列を解釈できず属性耐性は 0、状態異常レジストは 16 種中 1 種程度しか拾えていなかった) のを修正し、合わせてテナシティ (RUN ジョブ特性) を反映する。

### 含まれる commit

1. `576c438` [Fix] 装備の属性耐性 (耐火/耐氷 等) を正しく抽出
   - items.json は属性アイコンを private-use Unicode (``〜``) で持っているため正規化を追加
2. `f6bebb5` [Feature] 全属性耐性 / 全耐性 を 8 属性すべてに加減算
   - イリダルスタッフ「All elemental resistances +15」、霊亀棍「Resist all elements +20」等
3. `a7e63f2` [Fix] 状態異常レジストの抽出精度を上げ、テナシティをステータスに反映
   - items.json 実 EN 表記 (`"Resist X"+N`、Death `Resistance against "Death" +N` / `"Death" resistance +N`、Terror `Terror resistance +N`) に regex を整合
   - 「全状態異常のレジスト+N」(Staunch Tathlum 等) をデス耐性以外の 15 種に一括加算 (wiki 795.html)
   - ジョブ特性「テナシティ」(RUN Lv5/25/45/75/80/95、Lv99 で +15) を装備抽出値と同じく 15 種に加算
   - AUGMENT_JA_TO_EN に状態異常レジスト 18 エントリ追加 (custom_description の和名 augment も EN 化)

## Test plan

- [x] `node web/test/equip-stats-extraction.test.js` — 162 件すべてパス (新規 65 件追加)
- [x] `cd rust && cargo test --lib` — 既存 122 件パス (Rust 側変更なし)
- [ ] ブラウザで RUN/Lv99 を選択し、待機タブで状態異常レジスト 15 種が +15、デス欄が `-` を表示することを確認
- [ ] Staunch Tathlum +1 装備時、状態異常レジスト 15 種に +11 が加算されることを確認
- [ ] イリダルスタッフ装備時、属性耐性 8 種に +15 が加算されることを確認